### PR TITLE
my prayer feed and prayers from Rock

### DIFF
--- a/apollos-church-api/config.postgres.yml
+++ b/apollos-church-api/config.postgres.yml
@@ -290,7 +290,7 @@ TABS:
       type: PrayerList
       title: Daily Prayer
     - type: VerticalPrayerList
-      title: Your Prayers
+      title: Your prayers
   CONNECT:
     - type: ActionTable
       title: Connect to Apollos

--- a/apollos-church-api/src/data/action-algorithms/index.js
+++ b/apollos-church-api/src/data/action-algorithms/index.js
@@ -6,6 +6,7 @@ class dataSource extends ActionAlgorithm.dataSource {
     ...this.ACTION_ALGORITHMS,
     UPCOMING_EVENTS: this.upcomingEventsAlgorithm.bind(this),
     UPCOMING_STREAMS: this.allLiveStreamContentAlgorithm.bind(this),
+    PERSONAL_PRAYER: this.dailyPersonalPrayerAlgorithm.bind(this),
   };
 
   async upcomingEventsAlgorithm() {
@@ -38,6 +39,21 @@ class dataSource extends ActionAlgorithm.dataSource {
     const { LiveStream } = this.context.dataSources;
     const liveStreams = await LiveStream.getLiveStreams();
     return liveStreams;
+  }
+
+  async dailyPersonalPrayerAlgorithm({
+    limit = 10,
+    numberDaysSincePrayer,
+    personId,
+  } = {}) {
+    const { PrayerRequest, Feature } = this.context.dataSources;
+    Feature.setCacheHint({ scope: 'PRIVATE' });
+
+    return PrayerRequest.byPersonalPrayerFeed({
+      numberDaysSincePrayer,
+      personId,
+      limit,
+    });
   }
 }
 

--- a/apollos-church-api/src/data/features/data-source.js
+++ b/apollos-church-api/src/data/features/data-source.js
@@ -25,6 +25,31 @@ export default class Feature extends coreFeatures.dataSource {
     };
   }
 
+  async createVerticalPrayerListFeature({ title, subtitle, ...args }) {
+    const { ActionAlgorithm, Auth, Person } = this.context.dataSources;
+    const { id } = await Auth.getCurrentPerson();
+
+    // maps the person id, which right now is always from rock
+    // into the correct person id. Postgres if using Postgres, and Rock if using rock.
+    const { id: personId } = await Person.getFromId(id, null, {
+      originType: 'rock',
+    });
+    const prayers = () =>
+      ActionAlgorithm.runAlgorithms({
+        algorithms: ['PERSONAL_PRAYER'],
+        args: { personId, ...args },
+      });
+    return {
+      id: this.createFeatureId({
+        args: { personId, title, subtitle },
+      }),
+      prayers,
+      title,
+      subtitle,
+      __typename: 'VerticalPrayerListFeature',
+    };
+  }
+
   /** Create Feeds */
   getFeatures = async (featuresConfig = [], args = {}) =>
     Promise.all(

--- a/apollos-church-api/src/data/index.js
+++ b/apollos-church-api/src/data/index.js
@@ -33,7 +33,7 @@ import {
   // FeatureFeed,
   // ActionAlgorithm,
   // Event,
-  // PrayerRequest,
+  PrayerRequest,
   Persona,
 } from '@apollosproject/data-connector-rock';
 
@@ -53,7 +53,7 @@ import * as ActionAlgorithm from './action-algorithms';
 import * as Search from './search';
 import * as LiveStream from './live';
 import * as Schedule from './schedule';
-import * as PrayerRequest from './prayer';
+// import * as PrayerRequest from './prayer';
 
 // This modules ties together certain updates so they occurs in both Rock and Postgres.
 // Will be eliminated in the future through an enhancement to the Shovel

--- a/apollos-church-api/src/data/index.postgres.js
+++ b/apollos-church-api/src/data/index.postgres.js
@@ -26,7 +26,7 @@ import {
   BinaryFiles,
   FeatureFeed,
   // Event,
-  PrayerRequest,
+  // PrayerRequest,
   Person as RockPerson,
   ContentItem as RockContentItem,
   Campus as RockCampus,
@@ -45,7 +45,7 @@ import * as PostgresActionAlgorithm from './action-algorithms';
 // import * as Search from './search';
 import * as LiveStream from './livestream';
 import * as Schedule from './schedule';
-// import * as PrayerRequest from './prayer';
+import * as PrayerRequest from './prayer';
 
 // eslint-disable-next-line import/order
 import {
@@ -66,7 +66,7 @@ import {
   ContentItemsConnection,
   ContentItemCategory,
   // ActionAlgorithm as PostgresActionAlgorithm,
-  PrayerRequest as PostgresPrayerRequest,
+  // PrayerRequest as PostgresPrayerRequest,
 } from '@apollosproject/data-connector-postgres';
 
 import * as Theme from './theme';
@@ -90,7 +90,7 @@ const postgresContentModules = {
   ContentItem: PostgresContentItem,
   ContentItemsConnection,
   ContentChannel: ContentItemCategory,
-  PrayerRequest: PostgresPrayerRequest,
+  // PrayerRequest: PostgresPrayerRequest,
   RockCampus: { dataSource: RockCampus.dataSource },
   Campus,
   PostgresDefaultCampusOverride,
@@ -119,6 +119,7 @@ const data = {
     ? postgresContentModules
     : rockContentModules),
   Cloudinary,
+  PrayerRequest,
   Auth,
   AuthSms,
   Sms,

--- a/apollos-church-api/src/data/prayer/data-source.js
+++ b/apollos-church-api/src/data/prayer/data-source.js
@@ -1,4 +1,4 @@
-import { PrayerRequest as corePrayer } from '@apollosproject/data-connector-postgres';
+import { PrayerRequest as corePrayer } from '@apollosproject/data-connector-rock';
 import moment from 'moment-timezone';
 import ApollosConfig from '@apollosproject/config';
 
@@ -45,6 +45,81 @@ class PrayerRequest extends corePrayer.dataSource {
         .format(),
     });
     return this.getFromId(prayerId);
+  };
+
+  byDailyPrayerFeed = async ({ personId, numberDaysSincePrayer = 3 }) => {
+    const {
+      dataSources: { Auth },
+    } = this.context;
+
+    let excludedAliasId;
+    let primaryAliasId;
+    if (!personId) {
+      excludedAliasId = (await Auth.getCurrentPerson()).primaryAliasId;
+    } else {
+      primaryAliasId = await this.getPersonAliasId({ personId });
+    }
+
+    const prayers = await this.request()
+      .filter(
+        `RequestedByPersonAliasId ${
+          primaryAliasId ? `eq ${primaryAliasId}` : `ne ${excludedAliasId}`
+        }`
+      ) // don't show your own prayers
+      .andFilter(`IsActive eq true`) // prayers can be marked as "in-active" in Rock
+      .andFilter(`IsApproved eq true`) // prayers can be moderated in Rock
+      .andFilter('IsPublic eq true') // prayers can be set to private in Rock
+      .andFilter(
+        // prayers that aren't expired
+        `ExpirationDate gt datetime'${moment
+          .tz(ROCK.TIMEZONE)
+          .format()}' or ExpirationDate eq null`
+      )
+      .andFilter(
+        // prayers that were entered less then x days ago
+        `EnteredDateTime gt datetime'${moment
+          .tz(ROCK.TIMEZONE)
+          .subtract(numberDaysSincePrayer, 'day')
+          .format()}' or PrayerCount eq null` // include prayers that haven't prayed yet and within x number of days old
+      )
+      .andFilter(`Answer eq null or Answer eq ''`) // prayers that aren't answered
+      .sort([
+        { field: 'PrayerCount', direction: 'asc' }, // # of times prayed, ascending
+        { field: 'EnteredDateTime', direction: 'asc' }, // oldest prayer first
+      ])
+      .get();
+    return prayers;
+  };
+
+  byPersonalPrayerFeed = async ({ personId, numberDaysSincePrayer = 3 }) => {
+    const {
+      dataSources: { Auth },
+    } = this.context;
+
+    let excludedAliasId;
+    let primaryAliasId;
+    if (!personId) {
+      excludedAliasId = (await Auth.getCurrentPerson()).primaryAliasId;
+    } else {
+      primaryAliasId = await this.getPersonAliasId({ personId });
+    }
+
+    const prayers = await this.request()
+      .filter(
+        `RequestedByPersonAliasId ${
+          primaryAliasId ? `eq ${primaryAliasId}` : `ne ${excludedAliasId}`
+        }`
+      ) // don't show your own prayers
+      // .andFilter(`IsActive eq true`) // prayers can be marked as "in-active" in Rock
+      // .andFilter(`IsApproved eq true`) // prayers can be moderated in Rock
+      // .andFilter('IsPublic eq true') // prayers can be set to private in Rock
+      .andFilter(`Answer eq null or Answer eq ''`) // prayers that aren't answered
+      .sort([
+        { field: 'PrayerCount', direction: 'asc' }, // # of times prayed, ascending
+        { field: 'EnteredDateTime', direction: 'asc' }, // oldest prayer first
+      ])
+      .get();
+    return prayers;
   };
 }
 

--- a/apolloschurchapp/schema.graphql
+++ b/apolloschurchapp/schema.graphql
@@ -555,8 +555,8 @@ type Mutation {
   interactWithNode(action: InteractionAction!, nodeId: ID!, data: [InteractionDataField]): InteractionResult
   updateLikeEntity(input: LikeEntityInput!): ContentItem @deprecated(reason: "Use the more general updateLikeNode instead")
   updateLikeNode(input: LikeEntityInput!): Node
-  addPrayer(text: String!, isAnonymous: Boolean): PrayerRequest
   updateUserCampus(campusId: String!): Person
+  addPrayer(text: String!, isAnonymous: Boolean): PrayerRequest
   authenticate(identity: String!, password: String!): Authentication
   changePassword(password: String!): Authentication
   registerPerson(email: String!, password: String!, userProfile: [UpdateProfileInput]): Authentication
@@ -638,8 +638,8 @@ type Person implements Node {
   gender: GENDER
   birthDate: String
   photo: ImageMediaSource
-  prayers: [PrayerRequest]
   campus: Campus
+  prayers: [PrayerRequest]
   devices: [Device]
   groups(type: GROUP_TYPE, asLeader: Boolean): [Group]
   currentUserFollowing: Follow


### PR DESCRIPTION
Create my prayers feed to allow different filters of prayer requests and to see your prayers. I would like to add a button to this that allow us to mark a prayer as answered. right now this only filters on the unanswered prayers. The more prayers someone has the longer this will take to load. 